### PR TITLE
Flexible Plural Form Lookup

### DIFF
--- a/index.php
+++ b/index.php
@@ -28,12 +28,16 @@ function tp($key, array $data, $locale = null)
             $form = $pluralizer::formName($form);
             $translations = I18n::translation($locale)[$key] ?? null;
 
+            $formOther = $pluralizer::formName(Oblik\Pluralization\OTHER);
+
             if (is_array($translations)) {
-                $translation = $translations[$form] ?? null;
+                $translation = $translations[$form] ?? $translations[$formOther] ?? null;
+            } elseif (is_string($translations)) {
+                $translation = $translations;
             }
 
             if (empty($translation)) {
-                $translation = I18n::translation($locale)[$key . ".$form"] ?? null;
+                $translation = I18n::translation($locale)[$key . ".$form"] ?? I18n::translation($locale)[$key . ".$formOther"] ?? null;
             }
 
             if (is_string($translation)) {


### PR DESCRIPTION
Adds two features:

1. In the event that a specific form's translation is not found/empty, it defaults to the `other` case. The current behavior treats this as a completely missing translation.
For example, in English, there is no distinction between "1 sheep" and "2 sheep", so it's redundant to define it multiple times.

2. Adds special handling for the `'count' => 0` case so all languages can use a `zero` string.
This enables something like an English translation to have a more natural translation of "No apples" instead of "0 apples".
For the few languages that actually have a necessary `zero` case, the value `0`/`0.00` is already part of that set, so this effectively doesn't change behavior for those languages.

- - -

Example of valid count translations:

```php
return [
    'code' => 'en',
    'default' => true,
    'name' => 'English',
    'translations' => [
        'apples' => [
            'zero' => 'No apples',
            'one' => '{{ count }} apple',
            'other' => '{{ count }} apples',
        ],
        'sheep' => [
            'zero' => 'No sheep',
            'other' => '{{ count }} apples',
        ],
        'deer' => [
            'other' => '{{ count }} deer',
        ],
        'fish' => '{{ count }} fish',
        'cats' => '{{ count }} cats',
        'cats.one' => '{{ count }} cat',
    ]
];
``