### PR TITLE
Added shortcut functions tpc(), tpp(), and tpr()

### DIFF
--- a/index.php
+++ b/index.php
@@ -56,7 +56,7 @@ function tpc($key, $count, $locale = null)
     return tp($key, ['count' => $count], $locale);
 }
 
-function tpp($key, $position, $locale = null)
+function tpo($key, $position, $locale = null)
 {
     return tp($key, ['position' => $position], $locale);
 }

--- a/index.php
+++ b/index.php
@@ -50,3 +50,18 @@ function tp($key, array $data, $locale = null)
         return null;
     }
 }
+
+function tpc($key, $count, $locale = null)
+{
+    return tp($key, ['count' => $count], $locale);
+}
+
+function tpp($key, $position, $locale = null)
+{
+    return tp($key, ['position' => $position], $locale);
+}
+
+function tpr($key, $start, $end, $locale = null)
+{
+    return tp($key, ['start' => $start, 'end' => $end], $locale);
+}


### PR DESCRIPTION
This lets you shorten:
```php
tp('apples', [ 'count' => 1 ]);                 // 1 apple
tp('apples', [ 'count' => 3 ]);                 // 3 apples
tp('place', [ 'position' => 1 ]);               // 1st
tp('place', [ 'position' => 103 ]);             // 103rd
tp('cookies', [ 'start' => 3, 'end' => 4 ]);    // 3-4 cookies
```

into:
```php
tpc('apples', 1);        // 1 apple
tpc('apples', 3);        // 3 apples
tpo('place', 1);         // 1st
tpo('place', 103);       // 103rd
tpr('cookies', 3, 4);    // 3-4 cookies
```
